### PR TITLE
Exclude Antimatter Annihilation from GetComp<> caching.

### DIFF
--- a/1.3/Source/PerformanceOptimizer/Optimizations/Cache/Optimization_FasterGetCompReplacement.cs
+++ b/1.3/Source/PerformanceOptimizer/Optimizations/Cache/Optimization_FasterGetCompReplacement.cs
@@ -39,7 +39,7 @@ namespace PerformanceOptimizer
 
         public static HashSet<string> typesToSkip = new HashSet<string>
         {
-            "AnimalGenetics.ColonyManager+JobsWrapper", "AutoMachineTool", "NightVision.CombatHelpers", "RJWSexperience.UI.SexStatusWindow", "AntimatterAnnihilation.Buildings.Building_MultiRefuelable", "AntimatterAnnihilation.Buildings.Building_AlloyFusionMachine"
+            "AnimalGenetics.ColonyManager+JobsWrapper", "AutoMachineTool", "NightVision.CombatHelpers", "RJWSexperience.UI.SexStatusWindow", "AntimatterAnnihilation.Buildings.Building_MultiRefuelable", "AntimatterAnnihilation.Buildings.Building_AlloyFusionMachine", "AntimatterAnnihilation.Buildings.Building_CompositeRefiner"
         };
 
         public static HashSet<string> methodsToSkip = new HashSet<string>

--- a/1.3/Source/PerformanceOptimizer/Optimizations/Cache/Optimization_FasterGetCompReplacement.cs
+++ b/1.3/Source/PerformanceOptimizer/Optimizations/Cache/Optimization_FasterGetCompReplacement.cs
@@ -39,7 +39,7 @@ namespace PerformanceOptimizer
 
         public static HashSet<string> typesToSkip = new HashSet<string>
         {
-            "AnimalGenetics.ColonyManager+JobsWrapper", "AutoMachineTool", "NightVision.CombatHelpers", "RJWSexperience.UI.SexStatusWindow"
+            "AnimalGenetics.ColonyManager+JobsWrapper", "AutoMachineTool", "NightVision.CombatHelpers", "RJWSexperience.UI.SexStatusWindow", "AntimatterAnnihilation.Buildings.Building_MultiRefuelable", "AntimatterAnnihilation.Buildings.Building_AlloyFusionMachine"
         };
 
         public static HashSet<string> methodsToSkip = new HashSet<string>


### PR DESCRIPTION
Hi,
Antimatter Annihilation has a system that allows refueling with multiple different fuel types. This system relies on multiple CompRefuelable components being on the same building, and changes the order of them to trick Rimworld into using a different component when needed. Although it isn't the best solution, it works...

However GetComp caching breaks that system because re-ordering the component does not have the intended effect. This pull request should solve that by excluding the antimatter annihilation machines from the caching system. Let me know if there is a better way to do this.

Thanks.